### PR TITLE
Bug fixes for some degenerate input cases + unit tests

### DIFF
--- a/dragnet/__init__.py
+++ b/dragnet/__init__.py
@@ -1,8 +1,7 @@
 #! /usr/bin/env python
 
 from .arias import Arias
-from .kohlschuetter import KohlschuetterBase, Kohlschuetter, DragnetModelKohlschuetterFeatures, DragnetModelKohlschuetterExpanded, PartialBlock, KohlschuetterNormalized, KohlschuetterExpanded
+from .kohlschuetter import KohlschuetterBase, Kohlschuetter, DragnetModelKohlschuetterFeatures, DragnetModelKohlschuetterExpanded, PartialBlock, KohlschuetterNormalized, KohlschuetterExpanded, BlockifyError
 from .logistic_regression import LogisticRegression
 from .util import evaluation_metrics
-
 


### PR DESCRIPTION
Handle the cases where:

(1) lxml can't parse the document (raise a BlockifyError in this case)
(2) the document has less then three blocks.  return all content in this case
