### PR TITLE
Fix unicode problems in blockify

### DIFF
--- a/dragnet/kohlschuetter.py
+++ b/dragnet/kohlschuetter.py
@@ -218,7 +218,8 @@ class KohlschuetterBase(object):
     blocks = set([
         'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'div', 'table'
     ])
-    
+
+    re_non_alpha = re.compile('[\W_]', re.UNICODE)
 
     @staticmethod
     def blocks_from_tree(tree):
@@ -248,7 +249,7 @@ class KohlschuetterBase(object):
 
         blocks = KohlschuetterBase.blocks_from_tree(html)
         # only return blocks with some text content
-        return [ele for ele in blocks if re.sub('[\W_]', '', ele.text).strip() != '']
+        return [ele for ele in blocks if KohlschuetterBase.re_non_alpha.sub('', ele.text) != '']
 
 
     def analyze(self, s, blocks=False):

--- a/test/test_kohlschuetter.py
+++ b/test/test_kohlschuetter.py
@@ -133,6 +133,20 @@ class TestKohlschuetterBase(KohlschuetterUnitBase):
             [['the', 'registered', 'trademark', u'\xae']])
 
 
+    def test_all_non_english(self):
+        s = u"""<div> <div> \u03b4\u03bf\u03b3 </div> <div> <a href="summer">\xe9t\xe9</a> </div>
+         <div> \u62a5\u9053\u4e00\u51fa </div> </div>"""
+        blocks = KohlschuetterBase.blockify(s)
+        self.block_output_tokens(blocks,
+            [[u'\u03b4\u03bf\u03b3'],
+            [u'\xe9t\xe9'],
+            [u'\u62a5\u9053\u4e00\u51fa']])
+        self.link_output_tokens(blocks,
+            [[],
+             [u'\xe9t\xe9'],
+             []])
+
+
     def test_text_from_subtree(self):
         s = """<a href=".">WILL <img src="."> THIS PASS <b>THE TEST</b> ??</a>"""
         tree = etree.fromstring(s, etree.HTMLParser(recover=True))


### PR DESCRIPTION
Bug fix in blockify that removes all content that doesn't contain [a-zA-Z0-9_].

The model performance on the English language data is virtually unchanged.
