### PR TITLE
Make `BlockifyError`s a bit more descriptive

### DIFF
--- a/dragnet/blocks.pyx
+++ b/dragnet/blocks.pyx
@@ -846,10 +846,10 @@ class Blockifier(object):
                 etree.HTMLParser(recover=True, encoding=encoding,
                 remove_comments=True, remove_pis=True))
         except:
-            raise BlockifyError
+            raise BlockifyError, 'Could not blockify HTML'
         if html is None:
             # lxml sometimes doesn't raise an error but returns None
-            raise BlockifyError
+            raise BlockifyError, 'Could not blockify HTML'
 
         blocks = Blockifier.blocks_from_tree(html, pb, do_css, do_readability)
 


### PR DESCRIPTION
This just gives slightly more information on why an error is being raised when the blockifier can't blockify a document.