### PR TITLE
Add support for sklearn 0.20.x, closes #76

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ nose
 coverage
 Cython>=0.21.1
 lxml
-scikit-learn>=0.15.2,<=0.19.2
+scikit-learn>=0.15.2,<=0.20
 numpy
 scipy
 ftfy>=4.1.0,<5.0.0

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     install_requires=[
         'Cython>=0.21.1',
         'lxml',
-        'scikit-learn>=0.15.2,<=0.19.2',
+        'scikit-learn>=0.15.2,<=0.20',
         'numpy',
         'scipy',
         'ftfy>=4.1.0,<5.0.0'


### PR DESCRIPTION
Note: 0.20 is planned to be the last Python2-compatible release
Closes #76 