### PR TITLE
Macos build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
     - PYTHON=2.7
     - PYTHON=3.5
     - PYTHON=3.6
+    - PYTHON=3.7
 
 install:
   # use miniconda until travis supports python on osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
 language: python
 python:
+  - 2.7
   - 3.5
+  - 3.6
 
-env:
-  global:
-    - CONDA_INSTALL_PATH=$HOME/conda
-    - PROJ_DIR=$HOME/miniconda
-  matrix:
-    - PYTHON_VERSION='3.5'
-    - PYTHON_VERSION='2.7'
+os:
+  - linux
 
 sudo: required
 
@@ -22,33 +19,12 @@ before_install:
   - ls /etc/profile.d/
 
 install:
-  - export MINICONDA_VER='4.2.12'
-  - export MINICONDA_VARIANT='3'
-  - export OS_TYPE="Linux-x86_64.sh"
-  - sudo chmod 777 /etc/profile.d
-  - ls -la /etc/profile.d/
-  - wget -O - https://raw.githubusercontent.com/bomboradata/bootstrap-conda/master/bootstrap-conda.sh | bash
-  - sudo chmod 755 /etc/profile.d
-  - ls -la /etc/profile.d/
-  - source /etc/profile
-  - source /etc/profile.d/conda.sh
-  - echo "$PATH"
-  - echo "$PWD"
-  - ls -la $HOME
-  - conda update --all --yes --quiet
-  - conda info
-  - conda list
-  - echo "$PATH"
-  - echo "$PWD"
+  - pip install -r requirements.txt
+  - pip list
+  - pip install .
 
 after_install:
   - ls /etc/profile.d/
 
 script:
-  - conda create --yes --quiet --name=dragnet-$PYTHON_VERSION python=$PYTHON_VERSION
-  - conda env update --quiet --name=dragnet-$PYTHON_VERSION --file=./env/env_dragnet.yml
-  - conda info
-  - conda list
-  - source activate dragnet-$PYTHON_VERSION
-  - make install-pip
-  - make test
+  - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,34 @@
-language: python
-python:
-  - 2.7
-  - 3.5
-  - 3.6
+language: generic
+sudo: required
 
 os:
   - linux
+  - osx
 
-sudo: required
-
-#cache:
-#  apt: true
-#  pip: true
-#  directories:
-#    - $PROJ_DIR
-
-before_install:
-  - ls /etc/profile.d/
+env:
+  matrix:
+    - PYTHON=2.7
+    - PYTHON=3.5
+    - PYTHON=3.6
 
 install:
+  # use miniconda until travis supports python on osx
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O ~/miniconda.sh;
+    elif [ "$TRAVIS_OS_NAME" == "linux" ]; then
+    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh;
+    fi
+  - bash ~/miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - conda create --yes -n python-env python=$PYTHON
+  - source activate python-env
+
   - pip install -r requirements.txt
   - pip list
   - pip install .
 
 after_install:
-  - ls /etc/profile.d/
+  - pip list
 
 script:
   - pytest

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@
 
 import os.path
 import lxml
+import platform
 import sys
 
 from setuptools import setup
@@ -39,6 +40,12 @@ def find_libxml2_include():
             include_dirs.append(d)
     return include_dirs
 
+# set min MacOS version, if necessary
+if sys.platform == 'darwin':
+    os_version = '.'.join(platform.mac_ver()[0].split('.')[:2])
+    # this seems to work better than the -mmacosx-version-min flag
+    os.environ['MACOSX_DEPLOYMENT_TARGET'] = os_version
+
 ext_modules = [
     Extension('dragnet.lcs',
               sources=["dragnet/lcs.pyx"],
@@ -52,7 +59,7 @@ ext_modules = [
     Extension('dragnet.features._readability',
               sources=["dragnet/features/_readability.pyx"],
               include_dirs=[get_include()],
-              extra_compile_args=['-std=c++11'] + (['-mmacosx-version-min=10.9'] if sys.platform.startswith("darwin") else []),
+              extra_compile_args=['-std=c++11'],
               language="c++"),
     Extension('dragnet.features._kohlschuetter',
               sources=["dragnet/features/_kohlschuetter.pyx"],

--- a/setup.py
+++ b/setup.py
@@ -22,16 +22,16 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import os.path
-import lxml
 import platform
+from setuptools import setup
+# have to import `Extension` after `setuptools.setup`
+from distutils.extension import Extension
 import sys
 
-from setuptools import setup
-from numpy import get_include
-from distutils.extension import Extension
 from Cython.Distutils import build_ext
 from Cython.Build import cythonize
-
+import lxml
+from numpy import get_include
 
 def find_libxml2_include():
     include_dirs = []

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     packages=['dragnet', 'dragnet.features'],
     package_dir={'dragnet': 'dragnet', 'dragnet.features': 'dragnet/features'},


### PR DESCRIPTION
Recently I was having problems installing dragnet on MacOS, so I was messing around with how to solve the problem and found that using the `MACOSX_DEPLOYMENT_TARGET` environment variable seems to work better than using the `-mmacosx-version-min` compiler flag. That said, I don't know exactly _why_ this works better, so if there is a better way of doing this I'm open to it.

Additionally, I wanted to add MacOS to Travis to hopefully keep that build up-to-date. I know we don't have Travis set up with the repository yet though... I think this has to be done by someone who is a member of the dragbet-org organization.

Anyway, while I was making changes to the travis config I figured it would be a good time to clean a few things up... I'm happy to break this into separate PRs if it seems like too much, but I decided to keep it all together for now since the MacOS install issue is what motivated those changes.